### PR TITLE
🐛 Fix queue overflow when consumers stop reading

### DIFF
--- a/src/palabra_ai/adapter/file.py
+++ b/src/palabra_ai/adapter/file.py
@@ -48,8 +48,10 @@ class FileReader(Reader):
 
         debug("Converting audio to PCM16 format...")
         try:
-            self._pcm_data = await asyncio.to_thread(convert_any_to_pcm16,
-                raw_data, sample_rate=self._track_settings.sample_rate
+            self._pcm_data = await asyncio.to_thread(
+                convert_any_to_pcm16,
+                raw_data,
+                sample_rate=self._track_settings.sample_rate,
             )
             debug(f"Converted to {len(self._pcm_data)} bytes")
         except Exception as e:

--- a/src/palabra_ai/base/task_event.py
+++ b/src/palabra_ai/base/task_event.py
@@ -1,5 +1,7 @@
 import asyncio
+
 from palabra_ai.util.logger import debug
+
 
 class TaskEvent(asyncio.Event):
     _owner: str = ""

--- a/src/palabra_ai/internal/_ws_q_tools.py
+++ b/src/palabra_ai/internal/_ws_q_tools.py
@@ -1,0 +1,24 @@
+import asyncio
+from typing import Any
+
+from palabra_ai.util.logger import debug
+
+
+async def receive(q, timeout: int | float | None = None) -> dict[str, Any] | None:
+    if timeout is None:
+        try:
+            return await q.get()
+        except asyncio.CancelledError:
+            debug("WebSocketClient receive cancelled")
+            raise
+    try:
+        return await asyncio.wait_for(q.get(), timeout=timeout)
+    except TimeoutError:
+        return None
+    except asyncio.CancelledError:
+        debug("WebSocketClient receive with timeout cancelled")
+        raise
+
+
+def mark_received(q):
+    q.task_done()

--- a/src/palabra_ai/util/logger.py
+++ b/src/palabra_ai/util/logger.py
@@ -1,8 +1,8 @@
 import sys
-from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
-from pathlib import Path
 from dataclasses import dataclass, field
-from functools import wraps
+from logging import DEBUG, INFO, WARNING
+from pathlib import Path
+
 from loguru import logger
 
 
@@ -36,10 +36,12 @@ class Library:
 
     def create_console_filter(self, original_filter):
         """Create a filter that combines library filtering with original."""
+
         def combined_filter(record):
             if not self.should_log(record):
                 return False
             return original_filter(record) if original_filter else True
+
         return combined_filter
 
     def create_file_filter(self):
@@ -110,5 +112,13 @@ exception = logger.exception
 trace = logger.trace
 
 
-__all__ = ["debug", "info", "warning", "error", "critical",
-           "exception", "trace", "set_logging"]
+__all__ = [
+    "debug",
+    "info",
+    "warning",
+    "error",
+    "critical",
+    "exception",
+    "trace",
+    "set_logging",
+]

--- a/tests/internal/test_internal_realtime.py
+++ b/tests/internal/test_internal_realtime.py
@@ -40,9 +40,17 @@ class TestPalabraRTClient:
         async with asyncio.TaskGroup() as tg:
             client = PalabraRTClient(tg, "token", "wss://control", "wss://stream")
 
+            # Create a mock queue that always returns None (simulating timeout)
+            mock_queue = asyncio.Queue()
+            
+            # Mock the FanoutQueue
+            mock_fanout_queue = MagicMock()
+            mock_fanout_queue.subscribe = MagicMock(return_value=mock_queue)
+            mock_fanout_queue.unsubscribe = MagicMock()
+            
             client.wsc = MagicMock()
             client.wsc.send = AsyncMock()
-            client.wsc.receive = AsyncMock(return_value=None)
+            client.wsc.ws_out_foq = mock_fanout_queue
 
             with pytest.raises(TimeoutError):
                 await client.get_translation_settings(timeout=0.1)


### PR DESCRIPTION
## 📋 Summary
Fixed a critical bug where message queues could overflow when consumers stopped reading from them, causing memory issues and potential deadlocks in the WebSocket communication layer.

## 🎯 Problem
- Messages were being pushed to queues indefinitely
- No cleanup mechanism when consumers stopped reading
- Memory usage grew unbounded when consumers timed out or were cancelled
- Could lead to system instability in long-running sessions

## ✨ Changes

### 🔧 Core Fixes
- **New queue utilities module** (`_ws_q_tools.py`)
  - `receive()`: Safe message retrieval with timeout support
  - `mark_received()`: Proper task completion marking
  - Centralized error handling for cancelled operations

### 📦 Refactored Components
- **`PalabraRTClient.get_translation_settings()`**
  - ✅ Now uses subscription-based message consumption
  - ✅ Limited buffer size (5 messages) to prevent overflow
  - ✅ Automatic cleanup with `finally` block
  - ✅ Proper subscriber ID management

- **`WebSocketClient` improvements**
  - 🗑️ Removed unused `in_q_size` and `out_q_size` parameters
  - 🗑️ Eliminated redundant `ws_raw_out_foq` queue
  - 📉 Simplified message flow architecture

### 🧹 Code Quality
- Added proper import organization
- Improved debug logging for better troubleshooting
- Enhanced error handling throughout the async flow

## 🔬 Technical Details

### Before 🚫
```python
# Messages accumulated forever
message = await self.wsc.receive(1)
```

### After ✅
```python
# Controlled subscription with automatic cleanup
subscriber_id = "RT.get_translation_settings"
try:
    out_q = self.wsc.ws_out_foq.subscribe(subscriber_id, 5)
    message = await receive(out_q, 1)
finally:
    self.wsc.ws_out_foq.unsubscribe(subscriber_id)
```

## 🧪 Testing
- ✅ Updated unit tests to mock the new FanoutQueue subscription pattern
- ✅ Verified timeout handling with subscription-based approach
- ✅ Confirmed proper cleanup in cancellation scenarios

## 📊 Impact
- 🎉 **Memory usage**: Bounded queue sizes prevent unbounded growth
- 🎉 **Reliability**: Proper cleanup prevents resource leaks
- 🎉 **Performance**: Reduced memory pressure in long-running sessions
- 🎉 **Maintainability**: Centralized queue operations in dedicated module

## 🔄 Migration Notes
No breaking changes for external API users. Internal consumers of WebSocketClient should note the removed queue size parameters.